### PR TITLE
Adding the ability to install with composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Add the following to your magento project's composer.json file:
 {
     "require": {
         ...
-        "magento/module-baler": "^0.1.0-alpha"
+        "magento/module-baler": "^0.1.0"
     },
     ...
     "repositories": {
         ...
         "adifucan": {
             "type": "vcs",
-            "url": "git@github.com:adifucan/m2-baler.git"
+            "url": "git@github.com:adifucan/m2-baler.git",
+            "no-api": true
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ Magento_Baler module introduces functionality to preload JS bundles configuratio
 This functionality is disabled by default and it can be enabled on the configuration page (Stores -> Configuration -> Advanced -> Developer -> Javascript Settings).
 Developer settings is not displayed in production mode. To enable this feature in production mode, CLI command `bin/magento config:set dev/js/enable_baler_js_bundling 1` can be used.
 
+### Installing with composer
+Add the following to your magento project's composer.json file:
+```json
+{
+    "require": {
+        ...
+        "magento/module-baler": "^0.1.0"
+    },
+    ...
+    "repositories": {
+        ...
+        "adifucan": {
+            "type": "vcs",
+            "url": "git@github.com:adifucan/m2-baler.git"
+        }
+    }
+}
+```
+
+
 ### What is not implemented in this module yet:
 1. The following features should be disabled when Magento_Baler is enabled:
    - JS Bundling

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your magento project's composer.json file:
 {
     "require": {
         ...
-        "magento/module-baler": "^0.1.0"
+        "magento/module-baler": "^0.1.0-alpha"
     },
     ...
     "repositories": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "magento/module-store": "*"
     },
     "type": "magento2-module",
+    "version": "0.1.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,5 +6,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Baler"/>
+    <module name="Magento_Baler" setup_version="0.1.0">
+        <sequence>
+            <module name="Magento_Store"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
Adding the ability to install with composer directly from Github.
This requires that you create a tag/release (0.1.0 in this case) that composer can pull from.

Please feel free to request changes or reject this PR altogether if you don't want it. I won't be offended.